### PR TITLE
[LIB-65] 상품 소개 관리 수정 (do not merge)

### DIFF
--- a/src/axios/Product.js
+++ b/src/axios/Product.js
@@ -101,3 +101,14 @@ export const addProductIntroduction = (productId, imageFile) => {
     },
   });
 };
+
+export const modifyProductIntroduction = (productId, imageFile) => {
+  const formData = new FormData();
+  formData.append("imageFile", imageFile);
+  return request.patch(ADD_PRODUCT_INTRODUCTION(productId), formData, {
+    headers: {
+      Authorization: sessionStorage.getItem(ACCESS_TOKEN),
+      "Content-Type": "multipart/form-data",
+    },
+  });
+};

--- a/src/component/product/ProductIntroPanel.js
+++ b/src/component/product/ProductIntroPanel.js
@@ -3,23 +3,40 @@ import { Button } from "@mui/material";
 import { useState, useEffect } from "react";
 import { useParams } from "react-router-dom";
 import example from "../../image/preview-example.png";
-import { addProductIntroduction } from "../../axios/Product";
+import {
+  addProductIntroduction,
+  modifyProductIntroduction,
+} from "../../axios/Product";
 
 export default function ProductIntroPanel() {
   const { productId } = useParams();
   const [imgFile, setImgFile] = useState(undefined);
-
+  const [previousImg, setPreviousImg] = useState(undefined);
   useEffect(() => {
     // [TODO] 상품 소개 관리 조회 (관리자)
+    setPreviousImg(example);
     setImgFile(example);
   }, []);
 
   async function upload(productId, imgFile) {
-    if (imgFile) {
+    if (previousImg) {
+      // 기존 이미지 파일이 존재하는 경우
+      const response = await modifyProductIntroduction(productId, imgFile);
+      console.log(response.status);
+      if (response.status === 204) {
+        alert("이미지 수정 성공!");
+      } else {
+        alert(`[${response.status} ERROR] 이미지 수정 실패.`);
+      }
+    } else {
+      // 기존 이미지 파일이 존재하지 않는 경우
       const response = await addProductIntroduction(productId, imgFile);
-      if (response.status === 201) alert("소개 이미지 변경 성공!");
-      else alert(`[${response.status} ERROR] 소개 이미지 변경 실패.`);
-    } else alert("소개 이미지를 수정한 후 업로드가 가능합니다.");
+      if (response.status === 201) {
+        alert("이미지 추가 성공!");
+      } else {
+        alert(`[${response.status} ERROR] 이미지 추가 실패.`);
+      }
+    }
   }
 
   return (
@@ -58,7 +75,8 @@ export default function ProductIntroPanel() {
           type="submit"
           sx={{ fontWeight: "bold" }}
           variant="outlined"
-          disabled={imgFile === undefined}
+          // 이전과 같은 이미지일 경우 업로드버튼 비활성화
+          disabled={imgFile === previousImg}
         >
           업로드
         </Button>

--- a/src/component/product/ProductIntroPanel.js
+++ b/src/component/product/ProductIntroPanel.js
@@ -22,7 +22,6 @@ export default function ProductIntroPanel() {
     if (previousImg) {
       // 기존 이미지 파일이 존재하는 경우
       const response = await modifyProductIntroduction(productId, imgFile);
-      console.log(response.status);
       if (response.status === 204) {
         alert("이미지 수정 성공!");
       } else {


### PR DESCRIPTION
* [FEAT] 소개 이미지 수정

* [REFACTOR] 
이전 이미지(previousImg) 상태를 추가하여 업로드 로직을 일부 변경했습니다.
이전에는 이미지가 존재하지 않는것이 업로드의 조건이었다면 본 버전은 이전 이미지가 그 기준 역할을 합니다.
즉, 이미지가 없는 상태로도 수정을 할 수 있게 변경, 이미지에 변화가 없을 시 업로드 버튼을 비활성화하여 이전 이미지에 변화가 있을시에만(다른 이미지로 교체, 이미지 제거) 업로드할수있게 변경했어요. 

* [ISSUE]
로직은 올바르나 수정 api요청 시 405 에러가 발생합니다. aws쪽에서 제가 만들어놓은 수정 api가 아직 반영이 안된건지(로컬에서는 해당 api 테스트시 정상작동) requestbody로 건내는 formdata는 post와 get요청만 가능하다는 글을 봤는데 그게 문제인지 원인을 찾는 중입니다..! 확인하는대로 해결해서 머지할게요