### PR TITLE
[Issue121] 국내/외 선택 시 택배사 동기화

### DIFF
--- a/src/component/order/delivery/DeliveryDialog.js
+++ b/src/component/order/delivery/DeliveryDialog.js
@@ -24,7 +24,7 @@ const DeliveryDialog = ({ open, onClose, orderId }) => {
 
   useEffect(() => {
     getDeliveryList(international);
-  }, []);
+  }, [international]);
 
   const getDeliveryList = (international) => {
     getDeliveryCompanies(international).then((res) => {
@@ -41,7 +41,6 @@ const DeliveryDialog = ({ open, onClose, orderId }) => {
     const prevData = e.target.value;
     setInternational(prevData);
     setDeliveryCompanies([]);
-    getDeliveryList(international);
   };
 
   const handleChangeDeliveryInfo = (e) => {


### PR DESCRIPTION
### 원인

- setInternational 비동기 처리로 인하여 화면에는 국제지만 택배사 선택 시 국내 택배사가 보였음

### 해결

- useEffect의 dependency array에 international을 추가하여 international 값이 바뀔 때마다 리렌더링하게 함