### PR TITLE
feat: 주문상세정보 페이지 실시간배송조회 버튼 추가

### DIFF
--- a/src/constants/api.js
+++ b/src/constants/api.js
@@ -99,3 +99,8 @@ export const GET_DETAIL_LICENSE = (licenseImageId) => `/admin/licenseImage/${lic
 
 //상품 라이센스 옵션 api
 export const CUSTOM_LICENSE = () => `/admin/product`;
+
+// 실시간 배송정보 조회 api
+export const GET_REDIRECT_URL_OF_ORDER_DELIEVERY = (orderId, courierCode, trackingNumber) => 
+  `/product/orders/${orderId}/delivery?courierCode=${courierCode}&trackingNumber=${trackingNumber}`;
+  

--- a/src/screen/orders/OrderDetail.js
+++ b/src/screen/orders/OrderDetail.js
@@ -4,7 +4,7 @@ import './OrderDetail.css';
 import { Box } from '@mui/material';
 import { useParams, useNavigate } from 'react-router-dom';
 import React, { useState, useEffect } from 'react';
-import { fetchOrderDetail, upscaleImage } from '../../axios/Orders';
+import { fetchOrderDetail, upscaleImage, fetchRealTimeDeliveryInfo } from '../../axios/Orders';
 import Button from '../../component/common/Button';
 
 function Border() {
@@ -173,7 +173,7 @@ function OrderPerson({ order }) {
   );
 }
 
-function OrderDelivery({ order }) {
+function OrderDestination({ order }) {
   return (
     <>
       <h2>배송지 정보</h2>
@@ -193,6 +193,29 @@ function OrderDelivery({ order }) {
     </>
   );
 }
+
+function OrderDelivery({ order }) {
+  return (
+    <>
+      <div className="grid">
+        <div className='Order-common'>택배사 이름</div>
+        <div className='Order-common'>{order.orderDelivery?.name}</div>
+      </div>
+      <div className="grid">
+        <div className='Order-common'>운송장번호</div>
+        <div className='Order-common'>{order.orderDelivery?.trackingNumber}</div>
+      </div>
+      <Button 
+        text='배송조회'
+        onClick={() => {
+          const popup = window.open("about:blank", "배송조회", "width=500,height=700,top=100,left=100");
+          fetchRealTimeDeliveryInfo(order, popup)
+        }}
+      ></Button>
+    </>
+  );
+}
+
 function OrderPayment({ order }) {
   let paymentDetail;
 
@@ -330,7 +353,10 @@ export default function OrderDetail() {
           <OrderInquiryDelivery order={order} />
           <OrderInquiryDelivery2 order={order} />
           <OrderPerson order={order} />
-          <OrderDelivery order={order} />
+          <OrderDestination order={order} />
+          {order.orderDelivery !== null ? (
+            <OrderDelivery order={order} />
+          ) : (<></>)}
           <OrderPayment order={order} />
           <ReOrderDetail />
         </div>


### PR DESCRIPTION
관리자가 주문관리페이지에서 주문 상세정보 페이지로 이동하였을 때

배송시작된 주문인 경우에 한해서만 `택배사 이름` 및 `운송장번호`를 확인할 수 있도록 추가하였으며,
`배송조회` 버튼 클릭 시 스마트택배 API로 실시간배송정보를 확인할 수 있는 팝업을 추가하였습니다.

![image](https://github.com/Liberty52/admin-page/assets/42243302/b9f73b02-7926-49f6-9bce-ca64353c70c4)
