### PR TITLE
[ISSUE-137] npm 종속성으로 인한 build fail 문제 

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,7 +17,7 @@ jobs:
           node-version: 16
 
       - name: 의존성 설치
-        run: npm install
+        run: npm install --force
 
       - name: 빌드
         run: CI=false npm run build

--- a/multistage.Dockerfile
+++ b/multistage.Dockerfile
@@ -1,7 +1,7 @@
 FROM node:16 AS build
 WORKDIR /app
 COPY package*.json ./
-RUN npm install --production
+RUN npm install --production --force
 COPY . .
 RUN npm run build
 


### PR DESCRIPTION
### 관련 PR
Related #136 

### 문제 상황
`@toast-ui/react-editor` 의 의존성으로 인한 빌드 실패

![image](https://github.com/Liberty52/admin-page/assets/46955032/6d045e4c-31e0-4307-8f35-e3e49b56e1bf)

### 해결 방안
`npm install` 시  `--force` 나 `--legacy-peer-deps` 옵션 추가

### 코드
npm install 시 --force 설정 추가

```yml
# ci.yml
name: CI - 빌드
on:
  pull_request:
jobs:
  build:
    runs-on: ubuntu-latest
    steps:
      - name: 코드 체크아웃
        uses: actions/checkout@v2
      - name: Node.js 버전 설정
        uses: actions/setup-node@v2
        with:
          node-version: 16
      - name: 의존성 설치
        run: npm install --force
      - name: 빌드
        run: CI=false npm run build
```

```dockerfile
FROM node:16 AS build
WORKDIR /app
COPY package*.json ./
RUN npm install --production --force
COPY . .
RUN npm run build

FROM nginx:stable-alpine
RUN rm -rf /etc/nginx/conf.d
COPY conf /etc/nginx
COPY --from=build /app/build /usr/share/nginx/html
EXPOSE 80
CMD ["nginx", "-g", "daemon off;"]
```



### 테스트

**ci 스크립트**
![image](https://github.com/Liberty52/admin-page/assets/46955032/37fe1465-eb0e-4e93-9477-62ffcfa46b6a)



**multistage docker 스크립트**
![image](https://github.com/Liberty52/admin-page/assets/46955032/4bcd280e-1580-4942-b79a-9e040f445ae2)

Close #137