### PR TITLE
[Fix] 상품 관리 페이지 삭제 시 알림 추가, 삭제 후 바로 이전 페이지 가게 변경 

### DIFF
--- a/src/axios/Product.js
+++ b/src/axios/Product.js
@@ -22,13 +22,7 @@ import {
 import { ACCESS_TOKEN } from '../constants/token';
 import { CONTENT_TYPE } from '../constants/content-type';
 
-// export const retrieveProduct = () => {
-//   return request.get(PRODUCT_LIST(), {
-//     headers: {
-//       Authorization: sessionStorage.getItem(ACCESS_TOKEN),
-//     },
-//   });
-// };
+
 export const retrieveProduct = (productOrder) => {
   // 상품 순서가 제공되었을 경우, 순서 업데이트를 위한 요청을 보낸다.
   if (productOrder) {

--- a/src/component/license/LicenseTable.js
+++ b/src/component/license/LicenseTable.js
@@ -153,9 +153,11 @@ export const LicenseTable = (props) => {
 
  
   const handleDelete = () => {
+    if (window.confirm('해당 제품을 삭제하시겠습니까?')) {
     deleteProduct(productId)
       .then((response) => {
         alert('상품이 성공적으로 삭제되었습니다.');
+        window.history.back(); 
       })
       .catch((error) => {
         // 삭제에 실패했을 때의 에러 처리 로직
@@ -175,8 +177,8 @@ export const LicenseTable = (props) => {
           alert('에러가 발생했습니다. 다시 시도해주세요.');
         }
       });
+    }
   };
-  
   return (
     <>
       <Dialog open={open} onClose={closeDialog}>


### PR DESCRIPTION
### 상품 관리 페이지 삭제 시 알림 추가, 삭제 후 바로 이전 페이지 가게 변경 

https://github.com/Liberty52/admin-page/assets/81145288/c390721d-75bd-45de-9f5c-6c701aa32c4c

